### PR TITLE
docs: add Hanzilla Jobs related resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ To contribute:
 
 > 💡 Want more help? Check out the `CONTRIBUTING.md` document for more information on how to contribute
 
+## Related current resources
+
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Free, daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new-grad, junior, and entry-level roles across tech, data, finance, engineering, business, and sciences.
+
 # 🎉 Winter 2025 Applications
 
 | Name | Location | Application Status | Notes | Date Posted |


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a related current Canadian student job-search resource.
- Uses the internships/co-ops deep link because this repo is internship-focused.

## Why
This Winter 2025 list is no longer the main active cycle, so a small related-resource link can help Canadian students find current internships/co-ops, new-grad, junior, and entry-level roles across tech/data plus adjacent fields.

## Verification
- `git diff --check`
